### PR TITLE
Bugfix Actuate.stop() and Actuate.reset()

### DIFF
--- a/com/eclecticdesignstudio/motion/Actuate.hx
+++ b/com/eclecticdesignstudio/motion/Actuate.hx
@@ -175,10 +175,13 @@ class Actuate {
 		
 		for (library in targetLibraries) {
 			
-			for (actuator in library) {
-				
-				actuator.stop (null, false, false);
-				
+			var length:Int = library.length;
+			var actuator:GenericActuator;
+			for (i in 0 ... length) {
+
+				actuator = library[length - i - 1];
+ 				actuator.stop (null, false, false);
+
 			}
 			
 		}
@@ -267,12 +270,15 @@ class Actuate {
 					
 				}
 				
-				for (actuator in library) {
-					
+				var length:Int = library.length;
+				var actuator:GenericActuator;
+				for (i in 0 ... length) {
+
+					actuator = library[length - i - 1];
 					actuator.stop (properties, complete, sendEvent);
-					
+						
 				}
-				
+					
 			}
 			
 		}


### PR DESCRIPTION
Actuate.stop() and Actuate.reset() failed to stop correctly if multiple actuators are associated with the same target.
