### PR TITLE
Fix SimpleActuator for (defaul,setter) properties in HTML5

### DIFF
--- a/com/eclecticdesignstudio/motion/actuators/SimpleActuator.hx
+++ b/com/eclecticdesignstudio/motion/actuators/SimpleActuator.hx
@@ -15,14 +15,14 @@ import flash.text.TextField;
  * @version 1.2
  */
 class SimpleActuator extends GenericActuator {
-	
-	
+
+
 	private var timeOffset:Float;
-	
+
 	private static var actuators:Array <SimpleActuator> = new Array <SimpleActuator> ();
 	private static var actuatorsLength:Int = 0;
 	private static var shape:Shape;
-	
+
 	private var active:Bool;
 	private var cacheVisible:Bool;
 	private var detailsLength:Int;
@@ -34,10 +34,10 @@ class SimpleActuator extends GenericActuator {
 	private var setVisible:Bool;
 	private var startTime:Float;
 	private var toggleVisible:Bool;
-	
-	
+
+
 	public function new (target:Dynamic, duration:Float, properties:Dynamic) {
-		
+
 		active = true;
 		propertyDetails = new Array <PropertyDetails> ();
 		sendChange = false;
@@ -47,415 +47,415 @@ class SimpleActuator extends GenericActuator {
 		setVisible = false;
 		toggleVisible = false;
 		startTime = Lib.getTimer () / 1000;
-		
+
 		super (target, duration, properties);
-		
+
 		if (shape == null) {
-			
+
 			shape = new Shape ();
 			Lib.current.stage.addEventListener (Event.ENTER_FRAME, shape_onEnterFrame);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	/**
 	 * @inheritDoc
 	 */
 	public override function autoVisible (?value:Null<Bool>):IGenericActuator {
-		
+
 		if (value == null) {
-			
+
 			value = true;
-			
+
 		}
-		
+
 		_autoVisible = value;
-		
+
 		if (!value) {
-			
+
 			toggleVisible = false;
-			
+
 			if (setVisible) {
-				
+
 				target.visible = cacheVisible;
-				
+
 			}
-			
+
 		}
-		
+
 		return this;
-		
+
 	}
-	
-	
+
+
 	/**
 	 * @inheritDoc
 	 */
 	public override function delay (duration:Float):IGenericActuator {
-		
+
 		_delay = duration;
 		timeOffset = startTime + duration;
-		
+
 		return this;
-		
+
 	}
-	
-	
+
+
 	private function initialize ():Void {
-		
+
 		var details:PropertyDetails;
 		var start:Float;
-		
+
 		for (i in Reflect.fields (properties)) {
-			
+
 			var isField = true;
-			
+
 			#if haxe_209
-			
+
 			if (#if flash false && #end Reflect.hasField (target, i)) {
-				
+
 				start = Reflect.field (target, i);
-				
+
 			} else {
-				
+
 				isField = false;
 				start = Reflect.getProperty (target, i);
-				
+
 			}
-			
+
 			#else
-			
+
 			start = Reflect.field (target, i);
-			
+
 			#end
-			
+
 			details = new PropertyDetails (target, i, start, Reflect.field (properties, i) - start, isField);
 			propertyDetails.push (details);
-			
+
 		}
-		
+
 		detailsLength = propertyDetails.length;
 		initialized = true;
-		
+
 	}
-	
-	
+
+
 	public override function move ():Void {
-		
+
 		toggleVisible = (Reflect.hasField (properties, "alpha") && Std.is (target, DisplayObject));
-		
+
 		if (toggleVisible && !target.visible && properties.alpha != 0) {
-			
+
 			setVisible = true;
 			cacheVisible = target.visible;
 			target.visible = true;
-			
+
 		}
-		
+
 		timeOffset = startTime;
 		actuators.push (this);
 		++actuatorsLength;
-		
+
 	}
-	
-	
+
+
 	/**
 	 * @inheritDoc
 	 */
 	public override function onUpdate (handler:Dynamic, parameters:Array <Dynamic> = null):IGenericActuator {
-		
+
 		_onUpdate = handler;
 		_onUpdateParams = parameters;
 		sendChange = true;
-		
+
 		return this;
-		
+
 	}
-	
-	
+
+
 	public override function pause ():Void {
-		
+
 		paused = true;
 		pauseTime = Lib.getTimer ();
-		
+
 	}
-	
-	
+
+
 	public override function resume ():Void {
-		
+
 		if (paused) {
-			
+
 			paused = false;
 			timeOffset += (Lib.getTimer () - pauseTime) / 1000;
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public override function stop (properties:Dynamic, complete:Bool, sendEvent:Bool):Void {
-		
+
 		if (active) {
-			
+
 			if (properties == null) {
-				
+
 				active = false;
-				
+
 				if (complete) {
-					
+
 					apply ();
-					
+
 				}
-				
+
 				this.complete (sendEvent);
 				return;
-				
+
 			}
-			
+
 			for (i in Reflect.fields (properties)) {
-				
+
 				if (Reflect.hasField (this.properties, i)) {
-					
+
 					active = false;
-					
+
 					if (complete) {
-						
+
 						apply ();
-						
+
 					}
-					
+
 					this.complete (sendEvent);
 					return;
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	private function update (currentTime:Float):Void {
-		
+
 		if (!paused) {
-			
+
 			var details:PropertyDetails;
 			var easing:Float;
 			var i:Int;
-			
+
 			var tweenPosition:Float = (currentTime - timeOffset) / duration;
-			
+
 			if (tweenPosition > 1) {
-				
+
 				tweenPosition = 1;
-				
+
 			}
-			
+
 			if (!initialized) {
-				
+
 				initialize ();
-				
+
 			}
-			
+
 			if (!special) {
-				
+
 				easing = _ease.calculate (tweenPosition);
-				
+
 				for (i in 0...detailsLength) {
-					
+
 					details = propertyDetails[i];
-					
+
 					if (details.isField) {
-						
-						Reflect.setField (details.target, details.propertyName, details.start + (details.change * easing));
-						
+
+						Reflect.setProperty (details.target, details.propertyName, details.start + (details.change * easing));
+
 					} else {
-						
+
 						#if haxe_209
 						Reflect.setProperty (details.target, details.propertyName, details.start + (details.change * easing));
 						#end
-						
+
 					}
-					
+
 				}
-				
+
 			} else {
-				
+
 				if (!_reverse) {
-					
+
 					easing = _ease.calculate (tweenPosition);
-					
+
 				} else {
-					
+
 					easing = _ease.calculate (1 - tweenPosition);
-					
+
 				}
-				
+
 				var endValue:Float;
-				
+
 				for (i in 0...detailsLength) {
-					
+
 					details = propertyDetails[i];
-					
+
 					if (_smartRotation && (details.propertyName == "rotation" || details.propertyName == "rotationX" || details.propertyName == "rotationY" || details.propertyName == "rotationZ")) {
-						
+
 						var rotation:Float = details.change % 360;
-						
+
 						if (rotation > 180) {
-							
+
 							rotation -= 360;
-							
+
 						} else if (rotation < -180) {
-							
+
 							rotation += 360;
-							
+
 						}
-						
+
 						endValue = details.start + rotation * easing;
-						
+
 					} else {
-						
+
 						endValue = details.start + (details.change * easing);
-						
+
 					}
-					
+
 					if (!_snapping) {
-						
+
 						if (details.isField) {
-							
+
 							Reflect.setField (details.target, details.propertyName, endValue);
-							
+
 						} else {
-							
+
 							#if haxe_209
 							Reflect.setProperty (details.target, details.propertyName, endValue);
 							#end
-							
+
 						}
-						
+
 					} else {
-						
+
 						if (details.isField) {
-							
+
 							Reflect.setField (details.target, details.propertyName, Math.round (endValue));
-							
+
 						} else {
-							
+
 							#if haxe_209
 							Reflect.setProperty (details.target, details.propertyName, Math.round (endValue));
 							#end
-							
+
 						}
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 			if (tweenPosition == 1) {
-				
+
 				if (_repeat == 0) {
-					
+
 					active = false;
-					
+
 					if (toggleVisible && target.alpha == 0) {
-						
+
 						target.visible = false;
-						
+
 					}
-					
+
 					complete (true);
 					return;
-					
+
 				} else {
-					
+
 					if (_onRepeat != null) {
-						
+
 						#if (neko && haxe_209)
-						
+
 						var args = _onRepeatParams != null ? _onRepeatParams : [];
 						untyped __dollar__call (_onRepeat , _onRepeat, args.__neko ());
-						
+
 						#else
-						
+
 						Reflect.callMethod (_onRepeat, _onRepeat, _onRepeatParams);
-						
+
 						#end
-						
+
 					}
-					
+
 					if (_reflect) {
-						
+
 						_reverse = !_reverse;
-						
+
 					}
-					
+
 					startTime = currentTime;
 					timeOffset = startTime + _delay;
-					
+
 					if (_repeat > 0) {
-						
+
 						_repeat --;
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 			if (sendChange) {
-				
+
 				change ();
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
-	
-	
+
+
+
+
 	// Event Handlers
-	
-	
-	
-	
+
+
+
+
 	private static function shape_onEnterFrame (event:Event):Void {
-		
+
 		var currentTime:Float = Lib.getTimer () / 1000;
 		var actuator:SimpleActuator;
-		
+
 		var j:Int = 0;
-		
+
 		for (i in 0...actuatorsLength) {
-			
+
 			actuator = actuators[j];
-			
+
 			if (actuator.active) {
-				
+
 				if (currentTime > actuator.timeOffset) {
-					
+
 					actuator.update (currentTime);
-					
+
 				}
-				
+
 				j++;
-				
+
 			} else {
-				
+
 				actuators.splice (j, 1);
 				--actuatorsLength;
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
SimpleActuator uses Reflect.setField() to set values. But if targetting HTML5 we have some property defined like

public var prop1 (default, _setProp1)  : Float;

Than setter for this property is never called on tweening.
Perhaps it's better to change all Reflect.setField() calls to Reflect.setProperty(). Or at least use #if html5 Reflect.setProperty() #else Reflect.setField() #end

As far as i know (however i can mistake) Reflect.setField() is not supposed to call setters or getters at all and it sets values directly to fields bypassing the setters.
