### PR TITLE
Iterate in reverse to avoid missing actuators as they are removed from the library.

### DIFF
--- a/motion/Actuate.hx
+++ b/motion/Actuate.hx
@@ -146,12 +146,10 @@ class Actuate {
 		
 		for (library in targetLibraries) {
 			
-			var length = library.length;
-			
-			for (i in 0...length) {
-				
+			var i = library.length - 1;
+			while (i >= 0) {
 				library[i].stop (null, false, false);
-				
+				i--;
 			}
 			
 		}
@@ -240,12 +238,10 @@ class Actuate {
 					
 				}
 				
-				var length = library.length;
-				
-				for (i in 0...length) {
-					
+				var i = library.length - 1;
+				while (i >= 0) {
 					library[i].stop (properties, complete, sendEvent);
-					
+					i--;
 				}
 				
 			}
@@ -315,12 +311,11 @@ class Actuate {
 				
 				if (overwrite) {
 					
-					var length = library.length;
+					var i = library.length - 1;
 					
-					for (i in 0...length) {
-						
+					while (i >= 0) {
 						library[i].stop (actuator.properties, false, false);
-						
+						i--;
 					}
 					
 				}


### PR DESCRIPTION
Fixes bug where adding multiple tweens to one object and then overwriting (or simply stopping them) would not stop all of them. 

What would happen is that the first actuator would be removed making the array indices "pop up" one step, while the iterator moved on to the next index, thus missing every other actuator and going past the end (since the stored length was now too big). 
