### PR TITLE
Calling Actuator.stop() can invalidate a library, so need to reacquire library afterwards

### DIFF
--- a/motion/Actuate.hx
+++ b/motion/Actuate.hx
@@ -330,6 +330,8 @@ class Actuate {
 						i--;
 					}
 					
+					library = getLibrary (actuator.target);
+					
 				}
 				
 				library.push (actuator);


### PR DESCRIPTION
To reproduce:

`Actuate.timer(0.4).onComplete(function () { Actuate.tween(sprite, 1, {x: 20}).ease(Quad.easeInOut); });
Actuate.timer(0.8).onComplete(function () { Actuate.tween(sprite, 1, {x: 40}).ease(Quad.easeInOut); });
Actuate.timer(1.2).onComplete(function () { Actuate.tween(sprite, 1, {x: 20}).ease(Quad.easeInOut); });
Actuate.timer(1.6).onComplete(function () { Actuate.tween(sprite, 1, {x: 0}).ease(Quad.easeInOut); });`

Tween 1 creates a new library 1 and adds itself to it.
Tween 2 looks at library 1 and stops tween 1, but by stopping tween 1 it removes library 1 as the library for this object (in `Actuator.unload()`). Then it adds itself to library 1.
Tween 3 looks for the library, but it can't find it. So it creates a new library 2 and adds itself to it, without stopping tween 2.

There may be other places that this can happen, I didn't look.
