### PR TITLE
Fix error with Timer class on cpp target

### DIFF
--- a/motion/actuators/SimpleActuator.hx
+++ b/motion/actuators/SimpleActuator.hx
@@ -549,8 +549,7 @@ class SimpleActuator extends GenericActuator {
 }
 
 
-#if (!nme && neko)
-
+#if (!nme && neko || !nme && cpp)
 
 // Custom haxe.Timer implementation for C++ and Neko
 


### PR DESCRIPTION
It was an error on cpp target without using openfl/nme:
motion/actuators/SimpleActuator.hx:75: characters 11-41 : haxe.Timer does not have a constructor

Fixed.
