### PR TITLE
MotionPath improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ Actuate.effects (MySprite, 1).filter (BlurFilter, { blurX: 10, blurY: 10 });
 You even can create bezier curves, and complete motion paths, like in the Flash IDE. Chain multiple path commands together to create one solid path you can tween your objects across using the MotionPathActuator
 
 ```haxe
-var path = new MotionPath ().bezier (100, 100, 50, 50).line (20, 20);
+var path = new MotionPath ()
+  .bezier (100, 100, 50, 50)                 // quadratic, 1 control point
+  .bezierN (200, 200, [50, 100], [50, 100])  // general, any number of control points
+  .bezierSpline ([100, 100], [50, 50])       // spline, passing through the given points
+  .line (20, 20);                            // linear
 Actuate.motionPath (MySprite, 1, { x: path.x, y: path.y });
 ```
 


### PR DESCRIPTION
Some bezier-related improvements:

1. implement bezier curves of arbitrary degree (passing an array of control points). Linear and quadratic curves are treated as special cases (without any overhead). The generic method is `bezierN` (as of "degree n", I couldn't think of a better name).

2. implement bezier "splines", that is smooth compositions of (cubic) beziers that pass **through** a given set of points (much easier to use than control points), using [this technique](https://www.particleincell.com/2012/bezier-splines/). This is similar to GreenSock's [thru](https://greensock.com/BezierPlugin-JS) beziers (at least the general concept, the exact generated path is likely different, I didn't even look at their "proprietary algorithm").

3. To make the implementation simple, I made `ComponentPath` accept arbitrary `IComponentPath` instances as path segments. In particular, this allows to use `ComponentPath` itself as a segment of a larger `ComponentPath`. So `BezierSplinePath` is naturally implemented as a `ComponentPath` subclass, which computes the bezier segments (once the start is known) and adds them to itself.



