### PR TITLE
Allow setting easing params

### DIFF
--- a/src/motion/easing/Back.hx
+++ b/src/motion/easing/Back.hx
@@ -14,13 +14,33 @@ class Back {
 	public static var easeOut (default, null):IEasing = new BackEaseOut (1.70158);
 	
 	
+	public static function easeInWith (s:Float):IEasing {
+
+		return new BackEaseIn (s);
+
+	}
+
+
+	public static function easeInOutWith (s:Float):IEasing {
+
+		return new BackEaseInOut (s);
+
+	}
+
+
+	public static function easeOutWith (s:Float):IEasing {
+
+		return new BackEaseOut (s);
+
+	}
+
 }
 
 
 private class BackEaseIn implements IEasing {
 	
 	
-	public var s:Float;
+	public var s (default, null):Float;
 	
 	
 	public function new (s:Float) {

--- a/src/motion/easing/Elastic.hx
+++ b/src/motion/easing/Elastic.hx
@@ -13,15 +13,35 @@ class Elastic {
 	public static var easeInOut (default, null):IEasing = new ElasticEaseInOut (0.1, 0.4);
 	public static var easeOut (default, null):IEasing = new ElasticEaseOut (0.1, 0.4);
 	
-	
+
+	public static function easeInWith (a:Float, p:Float):IEasing {
+
+		return new ElasticEaseIn (a, p);
+
+	}
+
+
+	public static function easeInOutWith (a:Float, p:Float):IEasing {
+
+		return new ElasticEaseInOut (a, p);
+
+	}
+
+
+	public static function easeOutWith (a:Float, p:Float):IEasing {
+
+		return new ElasticEaseOut (a, p);
+
+	}
+
 }
 
 
 private class ElasticEaseIn implements IEasing {
 	
 	
-	public var a:Float;
-	public var p:Float;
+	public var a (default, null):Float;
+	public var p (default, null):Float;
 	
 	
 	public function new (a:Float, p:Float) {


### PR DESCRIPTION
An unfortunate side-effect of 37a09ae48 is that it made impossible to set easing params for the classes that support them (`Elastic` and `Back`). This is because:

- sub-types (`ElasticEaseIn`, ...) are now private so they can't be used directly

- Before one could do:
  ```
  var ease = Elastic.easeIn;
  ease.a = 0.2;
  ```
  but now this will mess all tweens up!

Not sure what's the most elegant way of fixing this, but here's an attempt:

1. I added `easeInWith` / `easeInOutWith` / `easeOutWith` functions for passing params, eg:
  ```
  Actuate.tween (MySprite, 1, { alpha: 1 }).ease (Elastic.easeOutWith(0.3, 0.5));
  ```

2. I set the properties themselves to `(default, null)` to avoid surprises.

  


