### PR TITLE
Fix for resume when using manual time

### DIFF
--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -332,7 +332,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 				timeOffset += (Timer.stamp () - pauseTime);
 				#end
 			#else
-			timeOffset += (getTime() - pauseTime) / 1000;
+			timeOffset += (getTime() - pauseTime);
 			#end
 			
 			super.resume ();


### PR DESCRIPTION
There is an extra division by 1000 which is inconsistent with the other instances of getTime().