### PR TITLE
Replace Lime-specific html5 conditionals with js

### DIFF
--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -202,7 +202,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 			
 			#if (haxe_209 || haxe3)
 			
-			if (Reflect.hasField (target, i) #if flash && !untyped (target).hasOwnProperty ("set_" + i) #elseif html5 && !(untyped (target).__properties__ && untyped (target).__properties__["set_" + i]) #end) {
+			if (Reflect.hasField (target, i) #if flash && !untyped (target).hasOwnProperty ("set_" + i) #elseif js && !(untyped (target).__properties__ && untyped (target).__properties__["set_" + i]) #end) {
 				
 				start = Reflect.field (target, i);
 				
@@ -344,7 +344,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 	
 	#if !js @:generic #end private inline function setField<V> (target:V, propertyName:String, value:Dynamic):Void {
 		
-		if (Reflect.hasField (target, propertyName) #if flash && !untyped (target).hasOwnProperty ("set_" + propertyName) #elseif html5 && !(untyped (target).__properties__ && untyped (target).__properties__["set_" + propertyName]) #end) {
+		if (Reflect.hasField (target, propertyName) #if flash && !untyped (target).hasOwnProperty ("set_" + propertyName) #elseif js && !(untyped (target).__properties__ && untyped (target).__properties__["set_" + propertyName]) #end) {
 			
 			#if flash
 			untyped target[propertyName] = value;


### PR DESCRIPTION
When used outside of Lime, html5 likely isn't defined.

This entire logic seems a bit questionable though, why the complex check for whether it's a property or not instead of simply always calling `Reflect.setProperty()`?