### PR TITLE
Fix resuming tweens on JS target

### DIFF
--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -620,7 +620,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 			
 		}
 		
-		#if (!flash && !nme && !openfl && !lime && !actuate_manual_time && js)
+		#if (!flash && !nme && !openfl && !lime && !actuate_manual_update && js)
 		Browser.window.requestAnimationFrame(stage_onEnterFrame);
 		#end
 		

--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -302,7 +302,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 				#elseif lime
 				pauseTime = System.getTimer ();
 				#elseif js
-				pauseTime = Browser.window.performance.now () / 1000;
+				pauseTime = Browser.window.performance.now ();
 				#else
 				pauseTime = Timer.stamp ();
 				#end


### PR DESCRIPTION
Fixes resuming tweens on JS:

The new default timer for js either stores the pause time incorrectly or calculates the timeOffset incorrectly on resume; currently being stored in Seconds on pause, but treated as Milliseconds on resume.

One of 2 options should be chosen:
change pause to: pauseTime = Browser.window.performance.now ();
OR
change resume to: timeOffset += (Browser.window.performance.now () / 1000 - pauseTime);

Behaviour was that tweens would seem to remain paused after calling resume/resumeAll.

In exploring a workaround to this problem I found another problem with the actuate_manual_time & actuate_manual_update flags. I believe the incorrect flag is used within the stage_onEnterFrame function meaning you can't define only one of these flags without the other; because I was defining actuate_manual_time the stage_onEnterFrame would never be hooked up with requestAnimationFrame and so I had to also define actuate_manual_update to work around this.

Problem introduced in v1.8.8
Problem persists in v1.8.9