### PR TITLE
IGenericActuator: added goto() method that can manually change the current position

### DIFF
--- a/src/motion/actuators/GenericActuator.hx
+++ b/src/motion/actuators/GenericActuator.hx
@@ -454,4 +454,11 @@ class GenericActuator<T> implements IGenericActuator {
 	}
 	
 	
+	public function goto (position:Float):Void {
+		
+		
+		
+	}
+	
+	
 }

--- a/src/motion/actuators/IGenericActuator.hx
+++ b/src/motion/actuators/IGenericActuator.hx
@@ -103,6 +103,12 @@ interface IGenericActuator {
 	 */
 	public function onResume (handler:Dynamic, ?parameters:Array <Dynamic>):IGenericActuator;
 	
+	/**
+	 * Adjusts the tween to a specific position.
+	 * @param	position	The new position of the tween, between 0.0 and 1.0
+	 */
+	public function goto (position:Float):Void;
+	
 	
 	//private var properties:Dynamic;
 	private function apply ():Void;

--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -425,15 +425,89 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 		}
 		
 	}
+
+	override public function goto (tweenPosition:Float):Void {
+			
+		var details:PropertyDetails<U>;
+		var easing:Float;
+		var i:Int;
+			
+		if (!initialized) {
+			
+			initialize ();
+			
+		}
+		
+		if (!special) {
+			
+			easing = _ease.calculate (tweenPosition);
+			
+			for (i in 0...detailsLength) {
+				
+				details = propertyDetails[i];
+				setProperty (details, details.start + (details.change * easing));
+				
+			}
+			
+		} else {
+			
+			if (!_reverse) {
+				
+				easing = _ease.calculate (tweenPosition);
+				
+			} else {
+				
+				easing = _ease.calculate (1 - tweenPosition);
+				
+			}
+			
+			var endValue:Float;
+			
+			for (i in 0...detailsLength) {
+				
+				details = propertyDetails[i];
+				
+				if (_smartRotation && (details.propertyName == "rotation" || details.propertyName == "rotationX" || details.propertyName == "rotationY" || details.propertyName == "rotationZ")) {
+					
+					var rotation:Float = details.change % 360;
+					
+					if (rotation > 180) {
+						
+						rotation -= 360;
+						
+					} else if (rotation < -180) {
+						
+						rotation += 360;
+						
+					}
+					
+					endValue = details.start + rotation * easing;
+					
+				} else {
+					
+					endValue = details.start + (details.change * easing);
+					
+				}
+				
+				if (!_snapping) {
+					
+					setProperty (details, endValue);
+					
+				} else {
+					
+					setProperty (details, Math.round (endValue));
+					
+				}
+				
+			}
+			
+		}
+	}
 	
 	
 	private function update (currentTime:Float):Void {
 		
 		if (!paused) {
-			
-			var details:PropertyDetails<U>;
-			var easing:Float;
-			var i:Int;
 			
 			var tweenPosition:Float = (currentTime - timeOffset) / duration;
 			
@@ -442,77 +516,8 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 				tweenPosition = 1;
 				
 			}
-			
-			if (!initialized) {
-				
-				initialize ();
-				
-			}
-			
-			if (!special) {
-				
-				easing = _ease.calculate (tweenPosition);
-				
-				for (i in 0...detailsLength) {
-					
-					details = propertyDetails[i];
-					setProperty (details, details.start + (details.change * easing));
-					
-				}
-				
-			} else {
-				
-				if (!_reverse) {
-					
-					easing = _ease.calculate (tweenPosition);
-					
-				} else {
-					
-					easing = _ease.calculate (1 - tweenPosition);
-					
-				}
-				
-				var endValue:Float;
-				
-				for (i in 0...detailsLength) {
-					
-					details = propertyDetails[i];
-					
-					if (_smartRotation && (details.propertyName == "rotation" || details.propertyName == "rotationX" || details.propertyName == "rotationY" || details.propertyName == "rotationZ")) {
-						
-						var rotation:Float = details.change % 360;
-						
-						if (rotation > 180) {
-							
-							rotation -= 360;
-							
-						} else if (rotation < -180) {
-							
-							rotation += 360;
-							
-						}
-						
-						endValue = details.start + rotation * easing;
-						
-					} else {
-						
-						endValue = details.start + (details.change * easing);
-						
-					}
-					
-					if (!_snapping) {
-						
-						setProperty (details, endValue);
-						
-					} else {
-						
-						setProperty (details, Math.round (endValue));
-						
-					}
-					
-				}
-				
-			}
+
+			goto (tweenPosition);
 			
 			if (tweenPosition == 1) {
 				


### PR DESCRIPTION
Sometimes, I want to pause a tween and control it manually instead of letting it update automatically every frame. For instance, I might want to change the current position based on a Slider or another type of UI, like you would with video or audio.

## Example usage

```hx
var actuator = Actuate.tween(target, duration, props);
Actuate.pause(actuator);
actuator.goto(0.5);
```