### PR TITLE
SimpleActuator: fixed issue where properties could not be tweened in Neko

### DIFF
--- a/src/motion/actuators/SimpleActuator.hx
+++ b/src/motion/actuators/SimpleActuator.hx
@@ -370,7 +370,7 @@ class SimpleActuator<T, U> extends GenericActuator<T> {
 			#if flash
 			untyped details.target[details.propertyName] = value;
 			#else
-			Reflect.setField (details.target, details.propertyName, value);
+			Reflect.setProperty (details.target, details.propertyName, value);
 			#end
 			
 		} else {


### PR DESCRIPTION
Since Actuate is using `Reflect.setField()`, it does not work in Neko for properties of a class that have setters. This change makes Actuate use `Reflect.setProperty()` instead. This API works with both properties and fields, so it shouldn't break anything.

I guess that an alternative approach would be to change the call to `Reflect.hasField()` in `initialize()` that is currently used to detect if something is a field. [The documentation for `Reflect.hasField()`](https://api.haxe.org/Reflect.html#hasField) indicates that it may not work for classes, so Actuate probably shouldn't be using it there:

> This is only guaranteed to work for anonymous structures.